### PR TITLE
increased max header size for large auth tokens

### DIFF
--- a/vlab_router_api/app.ini
+++ b/vlab_router_api/app.ini
@@ -11,3 +11,4 @@ uid = nobody
 gid = nobody
 disable-logging = true
 enabled-threads = True
+buffer-size=32768


### PR DESCRIPTION
Increased the max HTTP header size in uWSGI to accommodate large auth tokens.